### PR TITLE
Restrict to binding existing NATS Jetstream consumers in Source

### DIFF
--- a/src/main/java/io/synadia/flink/source/js/NatsConsumerConfig.java
+++ b/src/main/java/io/synadia/flink/source/js/NatsConsumerConfig.java
@@ -8,25 +8,32 @@ public class NatsConsumerConfig implements Serializable {
 
     private final String consumerName;
     private final int batchSize;
+    private final String streamName;
+
 
     private NatsConsumerConfig(Builder builder) {
         this.consumerName = builder.consumerName;
         this.batchSize = builder.batchSize;
-
+        this.streamName=builder.streamName;
     }
 
     public String getConsumerName() {
         return consumerName;
     }
 
+    public String getStreamName() {
+        return streamName;
+    }
+
+
     public int getBatchSize() {
         return batchSize;
     }
 
-
     public static class Builder {
         private String consumerName;
         private int batchSize;
+        private String streamName;
 
         public Builder() {
         }
@@ -36,10 +43,17 @@ public class NatsConsumerConfig implements Serializable {
             return this;
         }
 
+        public Builder withStreamName(String streamName) {
+            this.streamName = streamName;
+            return this;
+        }
+
         public Builder withBatchSize(int batchSize) {
             this.batchSize = batchSize;
             return this;
         }
+
+
 
         public NatsConsumerConfig build() {
             return new NatsConsumerConfig(this);

--- a/src/main/java/io/synadia/flink/source/js/NatsJetstreamSource.java
+++ b/src/main/java/io/synadia/flink/source/js/NatsJetstreamSource.java
@@ -9,21 +9,17 @@ import io.synadia.flink.source.enumerator.NatsSourceEnumerator;
 import io.synadia.flink.source.split.NatsSubjectCheckpointSerializer;
 import io.synadia.flink.source.split.NatsSubjectSplit;
 import io.synadia.flink.source.split.NatsSubjectSplitSerializer;
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.List;
 import org.apache.flink.api.common.serialization.DeserializationSchema;
 import org.apache.flink.api.common.typeinfo.TypeInformation;
-import org.apache.flink.api.connector.source.Boundedness;
-import org.apache.flink.api.connector.source.Source;
-import org.apache.flink.api.connector.source.SourceReader;
-import org.apache.flink.api.connector.source.SourceReaderContext;
-import org.apache.flink.api.connector.source.SplitEnumerator;
-import org.apache.flink.api.connector.source.SplitEnumeratorContext;
+import org.apache.flink.api.connector.source.*;
 import org.apache.flink.api.java.typeutils.ResultTypeQueryable;
 import org.apache.flink.core.io.SimpleVersionedSerializer;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
 
 public class NatsJetstreamSource<OutputT> implements Source<OutputT, NatsSubjectSplit, Collection<NatsSubjectSplit>>, ResultTypeQueryable<OutputT> {
 

--- a/src/main/java/io/synadia/flink/source/js/NatsJetstreamSourceBuilder.java
+++ b/src/main/java/io/synadia/flink/source/js/NatsJetstreamSourceBuilder.java
@@ -3,19 +3,18 @@
 
 package io.synadia.flink.source.js;
 
-import static io.synadia.flink.Constants.SOURCE_STARTUP_JITTER_MAX;
-import static io.synadia.flink.Constants.SOURCE_STARTUP_JITTER_MIN;
-import static io.synadia.flink.Constants.SOURCE_SUBJECTS;
 import io.synadia.flink.Utils;
 import io.synadia.flink.common.NatsSinkOrSourceBuilder;
+import org.apache.flink.api.common.serialization.DeserializationSchema;
+
 import java.util.List;
 import java.util.Properties;
-import org.apache.flink.api.common.serialization.DeserializationSchema;
+
+import static io.synadia.flink.Constants.*;
 
 public class NatsJetstreamSourceBuilder<OutputT> extends NatsSinkOrSourceBuilder<NatsJetstreamSourceBuilder<OutputT>> {
 
     private DeserializationSchema<OutputT> deserializationSchema;
-
     private NatsConsumerConfig natsConsumerConfig;
 
     @Override

--- a/src/main/java/io/synadia/flink/source/js/NatsJetstreamSourceReader.java
+++ b/src/main/java/io/synadia/flink/source/js/NatsJetstreamSourceReader.java
@@ -3,25 +3,10 @@
 
 package io.synadia.flink.source.js;
 
-import static org.apache.flink.util.Preconditions.checkNotNull;
-import io.nats.client.Connection;
-import io.nats.client.JetStream;
-import io.nats.client.JetStreamApiException;
-import io.nats.client.JetStreamSubscription;
-import io.nats.client.Message;
-import io.nats.client.PullSubscribeOptions;
-import io.nats.client.Subscription;
-import io.nats.client.api.AckPolicy;
-import io.nats.client.api.ConsumerConfiguration;
+import io.nats.client.*;
 import io.synadia.flink.Utils;
 import io.synadia.flink.common.ConnectionFactory;
 import io.synadia.flink.source.split.NatsSubjectSplit;
-import java.io.IOException;
-import java.time.Duration;
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.List;
-import java.util.concurrent.CompletableFuture;
 import org.apache.flink.api.common.serialization.DeserializationSchema;
 import org.apache.flink.api.connector.source.ReaderOutput;
 import org.apache.flink.api.connector.source.SourceEvent;
@@ -32,6 +17,15 @@ import org.apache.flink.core.io.InputStatus;
 import org.apache.flink.util.FlinkRuntimeException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+
+import static org.apache.flink.util.Preconditions.checkNotNull;
 
 public class NatsJetstreamSourceReader<OutputT> implements SourceReader<OutputT, NatsSubjectSplit> {
 
@@ -71,10 +65,8 @@ public class NatsJetstreamSourceReader<OutputT> implements SourceReader<OutputT,
         try {
             connection = connectionFactory.connect();
             js = connection.jetStream();
-            ConsumerConfiguration consumerConfiguration = ConsumerConfiguration.builder().name(config.getConsumerName())
-                    .ackPolicy(AckPolicy.All).build();
             PullSubscribeOptions pullOptions = PullSubscribeOptions.builder()
-                    .configuration(consumerConfiguration).durable(config.getConsumerName())
+                    .stream(config.getStreamName()).bind(true).durable(config.getConsumerName())
                     .build();
             subscription = js.subscribe(subject, pullOptions);
         }

--- a/src/test/java/io/synadia/io/synadia/flink/NatsJetstreamSinkTest.java
+++ b/src/test/java/io/synadia/io/synadia/flink/NatsJetstreamSinkTest.java
@@ -5,17 +5,17 @@ package io.synadia.io.synadia.flink;
 
 import io.nats.client.api.StreamConfiguration;
 import io.nats.client.api.StreamInfo;
-import io.synadia.flink.sink.js.NATSJetstreamSinkBuilder;
-import io.synadia.flink.sink.js.NATSStreamConfig;
 import org.apache.flink.api.common.serialization.SimpleStringSchema;
 import org.apache.flink.streaming.api.datastream.DataStream;
 import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
 import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.*;
+
+import io.synadia.flink.sink.js.NATSJetstreamSinkBuilder;
+import io.synadia.flink.sink.js.NATSStreamConfig;
 
 import java.util.Collections;
 import java.util.Properties;
-
-import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class NatsJetstreamSinkTest extends TestBase {
 
@@ -24,7 +24,7 @@ public class NatsJetstreamSinkTest extends TestBase {
         String sinkSubject = "test-sink";
         String streamName = "test-stream";
 
-        runInExternalServer(true, (nc, url) -> {
+        runInServer(true, (nc, url) -> {
 
             Properties connectionProperties = defaultConnectionProperties(url);
             StreamConfiguration stream = new StreamConfiguration.Builder()


### PR DESCRIPTION
- Removed functionality that allowed the connector to create its own stream and consumers.
- Introduced usage of the `bind` method in NatsJetstreamSourceReader to attach to existing consumers.
- Refactored NatsJetstreamSourceBuilder to accept and propagate streamName, facilitating the binding process.