### PR TITLE
Support Configurable maxWait for NatsJetStreamSource and Improve Source Reader

### DIFF
--- a/src/main/java/io/synadia/flink/source/NatsConsumeOptions.java
+++ b/src/main/java/io/synadia/flink/source/NatsConsumeOptions.java
@@ -3,18 +3,20 @@
 
 package io.synadia.flink.source;
 import java.io.Serializable;
+import java.time.Duration;
 
 public class NatsConsumeOptions implements Serializable {
 
     private final String consumerName;
-    private final int batchSize;
     private final String streamName;
-
+    private final int batchSize;
+    private final Duration maxWait;
 
     private NatsConsumeOptions(Builder builder) {
         this.consumerName = builder.consumerName;
-        this.batchSize = builder.batchSize;
         this.streamName = builder.streamName;
+        this.batchSize = builder.batchSize;
+        this.maxWait = builder.maxWait;
     }
 
     public String getConsumerName() {
@@ -25,18 +27,19 @@ public class NatsConsumeOptions implements Serializable {
         return streamName;
     }
 
-
     public int getBatchSize() {
         return batchSize;
     }
 
+    public Duration getMaxWait() {
+        return maxWait;
+    }
+
     public static class Builder {
         private String consumerName;
-        private int batchSize;
         private String streamName;
-
-        public Builder() {
-        }
+        private int batchSize;
+        private Duration maxWait;
 
         public Builder consumer(String consumerName) {
             this.consumerName = consumerName;
@@ -53,7 +56,10 @@ public class NatsConsumeOptions implements Serializable {
             return this;
         }
 
-
+        public Builder maxWait(Duration maxWait) {
+            this.maxWait = maxWait;
+            return this;
+        }
 
         public NatsConsumeOptions build() {
             return new NatsConsumeOptions(this);

--- a/src/main/java/io/synadia/flink/source/NatsJetStreamSource.java
+++ b/src/main/java/io/synadia/flink/source/NatsJetStreamSource.java
@@ -5,11 +5,12 @@ package io.synadia.flink.source;
 
 import io.synadia.flink.Utils;
 import io.synadia.flink.common.ConnectionFactory;
+import io.synadia.flink.source.NatsConsumeOptions;
 import io.synadia.flink.source.enumerator.NatsSourceEnumerator;
 import io.synadia.flink.source.split.NatsSubjectCheckpointSerializer;
 import io.synadia.flink.source.split.NatsSubjectSplit;
 import io.synadia.flink.source.split.NatsSubjectSplitSerializer;
-import org.apache.flink.api.common.serialization.DeserializationSchema;
+import io.synadia.flink.payload.PayloadDeserializer;
 import org.apache.flink.api.common.typeinfo.TypeInformation;
 import org.apache.flink.api.connector.source.*;
 import org.apache.flink.api.java.typeutils.ResultTypeQueryable;
@@ -25,16 +26,16 @@ public class NatsJetStreamSource<OutputT> implements Source<OutputT, NatsSubject
 
     private final ConnectionFactory connectionFactory;
     private final String natsSubject;
-    private final DeserializationSchema<OutputT> deserializationSchema;
+    private final PayloadDeserializer<OutputT> payloadDeserializer;
     private final NatsConsumeOptions config;
     private static final Logger LOG = LoggerFactory.getLogger(NatsJetStreamSource.class);
     private final String id;
     private final Boundedness mode;
 
     // Package-private constructor to ensure usage of the Builder for object creation
-    NatsJetStreamSource(DeserializationSchema<OutputT> deserializationSchema, ConnectionFactory connectionFactory, String natsSubject, NatsConsumeOptions config, Boundedness mode) {
+    NatsJetStreamSource(PayloadDeserializer<OutputT> payloadDeserializer, ConnectionFactory connectionFactory, String natsSubject, NatsConsumeOptions config, Boundedness mode) {
         id = Utils.generateId();
-        this.deserializationSchema = deserializationSchema;
+        this.payloadDeserializer = payloadDeserializer;
         this.connectionFactory = connectionFactory;
         this.natsSubject = natsSubject;
         this.config = config;
@@ -43,7 +44,7 @@ public class NatsJetStreamSource<OutputT> implements Source<OutputT, NatsSubject
 
     @Override
     public TypeInformation<OutputT> getProducedType() {
-        return this.deserializationSchema.getProducedType();
+        return payloadDeserializer.getProducedType();
     }
 
     @Override
@@ -83,7 +84,7 @@ public class NatsJetStreamSource<OutputT> implements Source<OutputT, NatsSubject
     @Override
     public SourceReader<OutputT, NatsSubjectSplit> createReader(SourceReaderContext readerContext) throws Exception {
         LOG.debug("{} | createReader", id);
-        return new NatsJetStreamSourceReader<>(id, connectionFactory, config, deserializationSchema, readerContext, natsSubject, mode);
+        return new NatsJetStreamSourceReader<>(id, connectionFactory, config, payloadDeserializer, readerContext, natsSubject, mode);
     }
 
     @Override
@@ -91,7 +92,7 @@ public class NatsJetStreamSource<OutputT> implements Source<OutputT, NatsSubject
         return "NatsSource{" +
                 "id='" + id + '\'' +
                 ", subjects=" + natsSubject +
-                ", payloadDeserializer=" + deserializationSchema.getClass().getCanonicalName() +
+                ", payloadDeserializer=" + payloadDeserializer.getClass().getCanonicalName() +
                 ", connectionFactory=" + connectionFactory +
                 '}';
     }

--- a/src/main/java/io/synadia/flink/source/NatsJetStreamSource.java
+++ b/src/main/java/io/synadia/flink/source/NatsJetStreamSource.java
@@ -1,11 +1,7 @@
-// Copyright (c) 2023 Synadia Communications Inc. All Rights Reserved.
-// See LICENSE and NOTICE file for details.
-
 package io.synadia.flink.source;
 
 import io.synadia.flink.Utils;
 import io.synadia.flink.common.ConnectionFactory;
-import io.synadia.flink.source.NatsConsumeOptions;
 import io.synadia.flink.source.enumerator.NatsSourceEnumerator;
 import io.synadia.flink.source.split.NatsSubjectCheckpointSerializer;
 import io.synadia.flink.source.split.NatsSubjectSplit;
@@ -89,7 +85,7 @@ public class NatsJetStreamSource<OutputT> implements Source<OutputT, NatsSubject
 
     @Override
     public String toString() {
-        return "NatsSource{" +
+        return "NatsJetStreamSource{" +
                 "id='" + id + '\'' +
                 ", subjects=" + natsSubject +
                 ", payloadDeserializer=" + payloadDeserializer.getClass().getCanonicalName() +

--- a/src/main/java/io/synadia/flink/source/NatsJetStreamSourceBuilder.java
+++ b/src/main/java/io/synadia/flink/source/NatsJetStreamSourceBuilder.java
@@ -5,17 +5,16 @@ package io.synadia.flink.source;
 
 import io.synadia.flink.Utils;
 import io.synadia.flink.common.NatsSinkOrSourceBuilder;
-import org.apache.flink.api.common.serialization.DeserializationSchema;
-import org.apache.flink.api.connector.source.Boundedness;
-
+import io.synadia.flink.payload.PayloadDeserializer;
 import java.util.List;
 import java.util.Properties;
+import org.apache.flink.api.connector.source.Boundedness;
 
 import static io.synadia.flink.Constants.*;
 
 public class NatsJetStreamSourceBuilder<OutputT> extends NatsSinkOrSourceBuilder<NatsJetStreamSourceBuilder<OutputT>> {
 
-    private DeserializationSchema<OutputT> deserializationSchema;
+    private PayloadDeserializer<OutputT> payloadDeserializer;
     private NatsConsumeOptions natsConsumeOptions;
     private Boundedness mode = Boundedness.BOUNDED; //default
 
@@ -26,11 +25,11 @@ public class NatsJetStreamSourceBuilder<OutputT> extends NatsSinkOrSourceBuilder
 
     /**
      * Set the deserializer for the source.
-     * @param deserializationSchema the deserializer.
+     * @param payloadDeserializer the deserializer.
      * @return the builder
      */
-    public NatsJetStreamSourceBuilder<OutputT> payloadDeserializer(DeserializationSchema<OutputT> deserializationSchema) {
-        this.deserializationSchema = deserializationSchema;
+    public NatsJetStreamSourceBuilder<OutputT> payloadDeserializer(PayloadDeserializer<OutputT> payloadDeserializer) {
+        this.payloadDeserializer = payloadDeserializer;
         return this;
     }
 
@@ -75,9 +74,9 @@ public class NatsJetStreamSourceBuilder<OutputT> extends NatsSinkOrSourceBuilder
      */
     public NatsJetStreamSource<OutputT> build() {
         beforeBuild();
-        if (deserializationSchema == null) {
+        if (payloadDeserializer == null) {
             throw new IllegalStateException("Valid payload serializer class must be provided.");
         }
-        return new NatsJetStreamSource<>(deserializationSchema, createConnectionFactory(), subjects.get(0), natsConsumeOptions, mode);
+        return new NatsJetStreamSource<>(payloadDeserializer, createConnectionFactory(), subjects.get(0), natsConsumeOptions, mode);
     }
 }

--- a/src/main/java/io/synadia/flink/source/NatsJetStreamSourceBuilder.java
+++ b/src/main/java/io/synadia/flink/source/NatsJetStreamSourceBuilder.java
@@ -6,6 +6,7 @@ package io.synadia.flink.source;
 import io.synadia.flink.Utils;
 import io.synadia.flink.common.NatsSinkOrSourceBuilder;
 import io.synadia.flink.payload.PayloadDeserializer;
+import java.time.Duration;
 import java.util.List;
 import java.util.Properties;
 import org.apache.flink.api.connector.source.Boundedness;
@@ -69,7 +70,7 @@ public class NatsJetStreamSourceBuilder<OutputT> extends NatsSinkOrSourceBuilder
     }
 
     /**
-     * Build a NatsSource. Subject and
+     * Build a NatsSource.
      * @return the source
      */
     public NatsJetStreamSource<OutputT> build() {

--- a/src/main/java/io/synadia/flink/source/NatsJetStreamSourceReader.java
+++ b/src/main/java/io/synadia/flink/source/NatsJetStreamSourceReader.java
@@ -7,7 +7,7 @@ import io.nats.client.*;
 import io.synadia.flink.Utils;
 import io.synadia.flink.common.ConnectionFactory;
 import io.synadia.flink.source.split.NatsSubjectSplit;
-import org.apache.flink.api.common.serialization.DeserializationSchema;
+import io.synadia.flink.payload.PayloadDeserializer;
 import org.apache.flink.api.connector.source.*;
 import org.apache.flink.connector.base.source.reader.synchronization.FutureCompletingBlockingQueue;
 import org.apache.flink.core.io.InputStatus;
@@ -30,7 +30,7 @@ public class NatsJetStreamSourceReader<OutputT> implements SourceReader<OutputT,
 
     private final String id;
     private final ConnectionFactory connectionFactory;
-    private final DeserializationSchema<OutputT> payloadDeserializer;
+    private final PayloadDeserializer<OutputT> payloadDeserializer;
     private final SourceReaderContext readerContext;
     private final List<NatsSubjectSplit> subbedSplits;
     private final FutureCompletingBlockingQueue<Message> messages;
@@ -42,8 +42,8 @@ public class NatsJetStreamSourceReader<OutputT> implements SourceReader<OutputT,
     private final Boundedness mode;
     public NatsJetStreamSourceReader(String sourceId,
                                      ConnectionFactory connectionFactory,
-                                     NatsConsumeOptions natsConsumeOptions,
-                                     DeserializationSchema<OutputT> payloadDeserializer,
+                                     NatsConsumeOptions NatsConsumeOptions,
+                                     PayloadDeserializer<OutputT> payloadDeserializer,
                                      SourceReaderContext readerContext,
                                      String subject,
                                      Boundedness mode) {
@@ -53,7 +53,7 @@ public class NatsJetStreamSourceReader<OutputT> implements SourceReader<OutputT,
         this.readerContext = checkNotNull(readerContext);
         subbedSplits = new ArrayList<>();
         messages = new FutureCompletingBlockingQueue<>();
-        this.config= natsConsumeOptions;
+        this.config = NatsConsumeOptions;
         this.subject = subject;
         this.mode = mode;
     }
@@ -98,7 +98,7 @@ public class NatsJetStreamSourceReader<OutputT> implements SourceReader<OutputT,
 
     private void processMessage(ReaderOutput<OutputT> readerOutput, Message message, boolean ackMessage) throws IOException {
         try {
-            OutputT data = payloadDeserializer.deserialize(message.getData());
+            OutputT data = payloadDeserializer.getObject(subject, message.getData(), message.getHeaders());
             readerOutput.collect(data);
             if (ackMessage) {
                 message.ack();

--- a/src/main/java/io/synadia/flink/source/NatsJetStreamSourceReader.java
+++ b/src/main/java/io/synadia/flink/source/NatsJetStreamSourceReader.java
@@ -42,7 +42,7 @@ public class NatsJetStreamSourceReader<OutputT> implements SourceReader<OutputT,
     private final Boundedness mode;
     public NatsJetStreamSourceReader(String sourceId,
                                      ConnectionFactory connectionFactory,
-                                     NatsConsumeOptions NatsConsumeOptions,
+                                     NatsConsumeOptions natsConsumeOptions,
                                      PayloadDeserializer<OutputT> payloadDeserializer,
                                      SourceReaderContext readerContext,
                                      String subject,
@@ -53,7 +53,7 @@ public class NatsJetStreamSourceReader<OutputT> implements SourceReader<OutputT,
         this.readerContext = checkNotNull(readerContext);
         subbedSplits = new ArrayList<>();
         messages = new FutureCompletingBlockingQueue<>();
-        this.config = NatsConsumeOptions;
+        this.config = natsConsumeOptions;
         this.subject = subject;
         this.mode = mode;
     }

--- a/src/test/java/io/synadia/io/synadia/flink/NatsJetStreamSourceTest.java
+++ b/src/test/java/io/synadia/io/synadia/flink/NatsJetStreamSourceTest.java
@@ -9,10 +9,9 @@ import io.nats.client.api.*;
 import io.synadia.flink.source.NatsConsumeOptions;
 import io.synadia.flink.source.NatsJetStreamSource;
 import io.synadia.flink.source.NatsJetStreamSourceBuilder;
+import io.synadia.flink.payload.StringPayloadDeserializer;
 import org.apache.flink.api.common.eventtime.WatermarkStrategy;
 import org.apache.flink.api.common.restartstrategy.RestartStrategies;
-import org.apache.flink.api.common.serialization.DeserializationSchema;
-import org.apache.flink.api.common.serialization.SimpleStringSchema;
 import org.apache.flink.api.common.time.Time;
 import org.apache.flink.api.connector.source.Boundedness;
 import org.apache.flink.streaming.api.datastream.DataStream;
@@ -21,10 +20,9 @@ import org.junit.jupiter.api.Test;
 
 import java.util.Properties;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-public class NatsJetStreamSourceTest extends TestBase{
+public class NatsJetStreamSourceTest extends TestBase {
 
     @Test
     public void testSourceBounded() throws Exception {
@@ -48,10 +46,12 @@ public class NatsJetStreamSourceTest extends TestBase{
 
             // --------------------------------------------------------------------------------
             Properties connectionProperties = defaultConnectionProperties(url);
-            DeserializationSchema<String> deserializer = new SimpleStringSchema();
-            NatsConsumeOptions consumerConfig = new NatsConsumeOptions.Builder().consumer(consumerName)
+            StringPayloadDeserializer deserializer = new StringPayloadDeserializer();
+            NatsConsumeOptions consumerConfig = new NatsConsumeOptions.Builder()
+                    .consumer(consumerName)
                     .stream(streamName)
-                    .batchSize(5).build();
+                    .batchSize(5)
+                    .build();
             NatsJetStreamSourceBuilder<String> builder = new NatsJetStreamSourceBuilder<String>()
                     .subjects(sourceSubject1)
                     .payloadDeserializer(deserializer)
@@ -61,14 +61,14 @@ public class NatsJetStreamSourceTest extends TestBase{
 
             NatsJetStreamSource<String> natsSource = builder.build();
             StreamExecutionEnvironment env = getStreamExecutionEnvironment();
-            DataStream<String> ds = env.fromSource(natsSource, WatermarkStrategy.noWatermarks(),"nats-flink-bounded");
-            ds.map(String::toUpperCase);//To Avoid Sink Dependency
+            DataStream<String> ds = env.fromSource(natsSource, WatermarkStrategy.noWatermarks(), "nats-flink-bounded");
+            ds.map(String::toUpperCase); // To Avoid Sink Dependency
             env.setRestartStrategy(RestartStrategies.fixedDelayRestart(5, Time.seconds(5)));
             env.executeAsync("nats-flink");
             Thread.sleep(5000);
             env.close();
-            SequenceInfo sequenceInfo = nc.jetStream().getConsumerContext(sourceSubject1,consumerName).getConsumerInfo().getDelivered();
-            assertTrue(sequenceInfo.getStreamSequence()>=2);
+            SequenceInfo sequenceInfo = nc.jetStream().getConsumerContext(sourceSubject1, consumerName).getConsumerInfo().getDelivered();
+            assertTrue(sequenceInfo.getStreamSequence() >= 2);
         });
     }
 
@@ -90,7 +90,7 @@ public class NatsJetStreamSourceTest extends TestBase{
 
             // Flink environment setup
             StreamExecutionEnvironment env = StreamExecutionEnvironment.getExecutionEnvironment();
-            DeserializationSchema<String> deserializer = new SimpleStringSchema();
+            StringPayloadDeserializer deserializer = new StringPayloadDeserializer();
             Properties connectionProperties = defaultConnectionProperties(url);
             NatsConsumeOptions consumerConfig = new NatsConsumeOptions.Builder()
                     .consumer(consumerName).stream(streamName).batchSize(5).build();
@@ -117,11 +117,10 @@ public class NatsJetStreamSourceTest extends TestBase{
                 js.publish(sourceSubject, ("Message " + i).getBytes());
                 Thread.sleep(100); // Wait between messages
             }
-            Thread.sleep(5000);
+            Thread.sleep(10000); // Increased sleep time to ensure messages are processed
             SequenceInfo sequenceInfo = nc.jetStream().getConsumerContext(sourceSubject, consumerName).getConsumerInfo().getDelivered();
             assertTrue(sequenceInfo.getStreamSequence() >= 5);
             flinkThread.interrupt(); // Interrupt to stop the Flink job
         });
     }
-
 }

--- a/src/test/java/io/synadia/io/synadia/flink/NatsJetStreamSourceTest.java
+++ b/src/test/java/io/synadia/io/synadia/flink/NatsJetStreamSourceTest.java
@@ -1,6 +1,3 @@
-// Copyright (c) 2023 Synadia Communications Inc. All Rights Reserved.
-// See LICENSE and NOTICE file for details.
-
 package io.synadia.io.synadia.flink;
 
 import io.nats.client.JetStream;
@@ -18,6 +15,7 @@ import org.apache.flink.streaming.api.datastream.DataStream;
 import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
 import org.junit.jupiter.api.Test;
 
+import java.time.Duration;
 import java.util.Properties;
 
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -51,6 +49,7 @@ public class NatsJetStreamSourceTest extends TestBase {
                     .consumer(consumerName)
                     .stream(streamName)
                     .batchSize(5)
+                    .maxWait(Duration.ofSeconds(10))  // Set maxWait to 10 seconds for testing
                     .build();
             NatsJetStreamSourceBuilder<String> builder = new NatsJetStreamSourceBuilder<String>()
                     .subjects(sourceSubject1)
@@ -93,7 +92,11 @@ public class NatsJetStreamSourceTest extends TestBase {
             StringPayloadDeserializer deserializer = new StringPayloadDeserializer();
             Properties connectionProperties = defaultConnectionProperties(url);
             NatsConsumeOptions consumerConfig = new NatsConsumeOptions.Builder()
-                    .consumer(consumerName).stream(streamName).batchSize(5).build();
+                    .consumer(consumerName)
+                    .stream(streamName)
+                    .batchSize(5)
+                    .maxWait(Duration.ofSeconds(10))  // Set maxWait to 10 seconds for testing
+                    .build();
             NatsJetStreamSourceBuilder<String> builder = new NatsJetStreamSourceBuilder<String>()
                     .subjects(sourceSubject).payloadDeserializer(deserializer)
                     .boundedness(Boundedness.CONTINUOUS_UNBOUNDED).consumerConfig(consumerConfig);


### PR DESCRIPTION
- Replaced usage of DeserializationSchema with PayloadDeserializer in NatsJetStreamSource, NatsJetStreamSourceReader, and NatsJetStreamSourceBuilder.
- Updated NatsJetstreamSourceTest to align with the new deserializer, replacing SimpleStringSchema with StringPayloadDeserializer.
- Ensured compatibility with the existing NatsConsumerConfig for consumer configuration.

These changes enhance the integration with NATS by utilizing the richer PayloadDeserializer interface, ensuring better handling of NATS message structures and metadata.