### PR TITLE
Support Configurable maxWait for NatsJetStreamSource and Improve Sour…

### DIFF
--- a/src/main/java/io/synadia/flink/source/NatsConsumeOptions.java
+++ b/src/main/java/io/synadia/flink/source/NatsConsumeOptions.java
@@ -3,18 +3,20 @@
 
 package io.synadia.flink.source;
 import java.io.Serializable;
+import java.time.Duration;
 
 public class NatsConsumeOptions implements Serializable {
 
     private final String consumerName;
-    private final int batchSize;
     private final String streamName;
-
+    private final int batchSize;
+    private final Duration maxWait;
 
     private NatsConsumeOptions(Builder builder) {
         this.consumerName = builder.consumerName;
-        this.batchSize = builder.batchSize;
         this.streamName = builder.streamName;
+        this.batchSize = builder.batchSize;
+        this.maxWait = builder.maxWait;
     }
 
     public String getConsumerName() {
@@ -25,18 +27,19 @@ public class NatsConsumeOptions implements Serializable {
         return streamName;
     }
 
-
     public int getBatchSize() {
         return batchSize;
     }
 
+    public Duration getMaxWait() {
+        return maxWait;
+    }
+
     public static class Builder {
         private String consumerName;
-        private int batchSize;
         private String streamName;
-
-        public Builder() {
-        }
+        private int batchSize;
+        private Duration maxWait;
 
         public Builder consumer(String consumerName) {
             this.consumerName = consumerName;
@@ -53,7 +56,10 @@ public class NatsConsumeOptions implements Serializable {
             return this;
         }
 
-
+        public Builder maxWait(Duration maxWait) {
+            this.maxWait = maxWait;
+            return this;
+        }
 
         public NatsConsumeOptions build() {
             return new NatsConsumeOptions(this);

--- a/src/main/java/io/synadia/flink/source/NatsJetStreamSource.java
+++ b/src/main/java/io/synadia/flink/source/NatsJetStreamSource.java
@@ -1,6 +1,3 @@
-// Copyright (c) 2023 Synadia Communications Inc. All Rights Reserved.
-// See LICENSE and NOTICE file for details.
-
 package io.synadia.flink.source;
 
 import io.synadia.flink.Utils;
@@ -9,7 +6,7 @@ import io.synadia.flink.source.enumerator.NatsSourceEnumerator;
 import io.synadia.flink.source.split.NatsSubjectCheckpointSerializer;
 import io.synadia.flink.source.split.NatsSubjectSplit;
 import io.synadia.flink.source.split.NatsSubjectSplitSerializer;
-import org.apache.flink.api.common.serialization.DeserializationSchema;
+import io.synadia.flink.payload.PayloadDeserializer;
 import org.apache.flink.api.common.typeinfo.TypeInformation;
 import org.apache.flink.api.connector.source.*;
 import org.apache.flink.api.java.typeutils.ResultTypeQueryable;
@@ -25,16 +22,16 @@ public class NatsJetStreamSource<OutputT> implements Source<OutputT, NatsSubject
 
     private final ConnectionFactory connectionFactory;
     private final String natsSubject;
-    private final DeserializationSchema<OutputT> deserializationSchema;
+    private final PayloadDeserializer<OutputT> payloadDeserializer;
     private final NatsConsumeOptions config;
     private static final Logger LOG = LoggerFactory.getLogger(NatsJetStreamSource.class);
     private final String id;
     private final Boundedness mode;
 
     // Package-private constructor to ensure usage of the Builder for object creation
-    NatsJetStreamSource(DeserializationSchema<OutputT> deserializationSchema, ConnectionFactory connectionFactory, String natsSubject, NatsConsumeOptions config, Boundedness mode) {
+    NatsJetStreamSource(PayloadDeserializer<OutputT> payloadDeserializer, ConnectionFactory connectionFactory, String natsSubject, NatsConsumeOptions config, Boundedness mode) {
         id = Utils.generateId();
-        this.deserializationSchema = deserializationSchema;
+        this.payloadDeserializer = payloadDeserializer;
         this.connectionFactory = connectionFactory;
         this.natsSubject = natsSubject;
         this.config = config;
@@ -43,7 +40,7 @@ public class NatsJetStreamSource<OutputT> implements Source<OutputT, NatsSubject
 
     @Override
     public TypeInformation<OutputT> getProducedType() {
-        return this.deserializationSchema.getProducedType();
+        return payloadDeserializer.getProducedType();
     }
 
     @Override
@@ -83,15 +80,15 @@ public class NatsJetStreamSource<OutputT> implements Source<OutputT, NatsSubject
     @Override
     public SourceReader<OutputT, NatsSubjectSplit> createReader(SourceReaderContext readerContext) throws Exception {
         LOG.debug("{} | createReader", id);
-        return new NatsJetStreamSourceReader<>(id, connectionFactory, config, deserializationSchema, readerContext, natsSubject, mode);
+        return new NatsJetStreamSourceReader<>(id, connectionFactory, config, payloadDeserializer, readerContext, natsSubject, mode);
     }
 
     @Override
     public String toString() {
-        return "NatsSource{" +
+        return "NatsJetStreamSource{" +
                 "id='" + id + '\'' +
                 ", subjects=" + natsSubject +
-                ", payloadDeserializer=" + deserializationSchema.getClass().getCanonicalName() +
+                ", payloadDeserializer=" + payloadDeserializer.getClass().getCanonicalName() +
                 ", connectionFactory=" + connectionFactory +
                 '}';
     }

--- a/src/main/java/io/synadia/flink/source/NatsJetStreamSource.java
+++ b/src/main/java/io/synadia/flink/source/NatsJetStreamSource.java
@@ -1,3 +1,6 @@
+// Copyright (c) 2023 Synadia Communications Inc. All Rights Reserved.
+// See LICENSE and NOTICE file for details.
+
 package io.synadia.flink.source;
 
 import io.synadia.flink.Utils;

--- a/src/main/java/io/synadia/flink/source/NatsJetStreamSourceBuilder.java
+++ b/src/main/java/io/synadia/flink/source/NatsJetStreamSourceBuilder.java
@@ -5,17 +5,17 @@ package io.synadia.flink.source;
 
 import io.synadia.flink.Utils;
 import io.synadia.flink.common.NatsSinkOrSourceBuilder;
-import org.apache.flink.api.common.serialization.DeserializationSchema;
-import org.apache.flink.api.connector.source.Boundedness;
-
+import io.synadia.flink.payload.PayloadDeserializer;
+import java.time.Duration;
 import java.util.List;
 import java.util.Properties;
+import org.apache.flink.api.connector.source.Boundedness;
 
 import static io.synadia.flink.Constants.*;
 
 public class NatsJetStreamSourceBuilder<OutputT> extends NatsSinkOrSourceBuilder<NatsJetStreamSourceBuilder<OutputT>> {
 
-    private DeserializationSchema<OutputT> deserializationSchema;
+    private PayloadDeserializer<OutputT> payloadDeserializer;
     private NatsConsumeOptions natsConsumeOptions;
     private Boundedness mode = Boundedness.BOUNDED; //default
 
@@ -26,11 +26,11 @@ public class NatsJetStreamSourceBuilder<OutputT> extends NatsSinkOrSourceBuilder
 
     /**
      * Set the deserializer for the source.
-     * @param deserializationSchema the deserializer.
+     * @param payloadDeserializer the deserializer.
      * @return the builder
      */
-    public NatsJetStreamSourceBuilder<OutputT> payloadDeserializer(DeserializationSchema<OutputT> deserializationSchema) {
-        this.deserializationSchema = deserializationSchema;
+    public NatsJetStreamSourceBuilder<OutputT> payloadDeserializer(PayloadDeserializer<OutputT> payloadDeserializer) {
+        this.payloadDeserializer = payloadDeserializer;
         return this;
     }
 
@@ -70,14 +70,14 @@ public class NatsJetStreamSourceBuilder<OutputT> extends NatsSinkOrSourceBuilder
     }
 
     /**
-     * Build a NatsSource. Subject and
+     * Build a NatsSource.
      * @return the source
      */
     public NatsJetStreamSource<OutputT> build() {
         beforeBuild();
-        if (deserializationSchema == null) {
+        if (payloadDeserializer == null) {
             throw new IllegalStateException("Valid payload serializer class must be provided.");
         }
-        return new NatsJetStreamSource<>(deserializationSchema, createConnectionFactory(), subjects.get(0), natsConsumeOptions, mode);
+        return new NatsJetStreamSource<>(payloadDeserializer, createConnectionFactory(), subjects.get(0), natsConsumeOptions, mode);
     }
 }

--- a/src/test/java/io/synadia/io/synadia/flink/NatsJetStreamSourceTest.java
+++ b/src/test/java/io/synadia/io/synadia/flink/NatsJetStreamSourceTest.java
@@ -1,3 +1,6 @@
+// Copyright (c) 2023 Synadia Communications Inc. All Rights Reserved.
+// See LICENSE and NOTICE file for details.
+
 package io.synadia.io.synadia.flink;
 
 import io.nats.client.JetStream;


### PR DESCRIPTION
* Refactor NATS JetStream Source to use PayloadDeserializer
- Replaced usage of DeserializationSchema with PayloadDeserializer in NatsJetStreamSource, NatsJetStreamSourceReader, and NatsJetStreamSourceBuilder.
- Updated NatsJetstreamSourceTest to align with the new deserializer, replacing SimpleStringSchema with StringPayloadDeserializer.
- Ensured compatibility with the existing NatsConsumerConfig for consumer configuration.

These changes enhance the integration with NATS by utilizing the richer PayloadDeserializer interface, ensuring better handling of NATS message structures and metadata.

* feat: Add configurable maxWait for NatsJetStreamSource

- Added maxWait configuration to NatsConsumeOptions.
- Updated NatsJetStreamSourceBuilder to accept maxWait.
- Modified NatsJetStreamSourceReader to use configurable maxWait.
- Refactored test cases to include maxWait configuration.

This change allows users to configure the maximum wait time for fetching messages from NATS JetStream, enhancing the flexibility and control over the message consumption process.

* fix camelCasing for object naming -fix camelCasing for object naming