### PR TITLE
Refactor tests: Add proper assertions and fix existing Jetstream tests

### DIFF
--- a/src/examples/java/io/synadia/flink/examples/v0/SourceToSinkJsExample.java
+++ b/src/examples/java/io/synadia/flink/examples/v0/SourceToSinkJsExample.java
@@ -14,6 +14,7 @@ import io.synadia.flink.v0.sink.NatsSinkBuilder;
 import org.apache.flink.api.common.eventtime.WatermarkStrategy;
 import org.apache.flink.api.common.restartstrategy.RestartStrategies;
 import org.apache.flink.api.common.time.Time;
+import org.apache.flink.api.connector.source.Boundedness;
 import org.apache.flink.streaming.api.datastream.DataStream;
 import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
 
@@ -60,7 +61,8 @@ public class SourceToSinkJsExample {
                 .connectionProperties(connectionProperties)
                 .consumerName(consumerName)
                 .maxFetchRecords(100)
-                .maxFetchTime(Duration.ofSeconds(5));
+                .maxFetchTime(Duration.ofSeconds(5))
+                .boundness(Boundedness.BOUNDED);
 
         NatsJetStreamSource<String> natsSource = builder.build();
 

--- a/src/examples/java/io/synadia/flink/examples/v0/SourceToSinkJsExample.java
+++ b/src/examples/java/io/synadia/flink/examples/v0/SourceToSinkJsExample.java
@@ -17,6 +17,7 @@ import org.apache.flink.api.common.time.Time;
 import org.apache.flink.streaming.api.datastream.DataStream;
 import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
 
+import java.time.Duration;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
@@ -57,7 +58,9 @@ public class SourceToSinkJsExample {
                 .subjects(sourceSubject)
                 .payloadDeserializer(deserializer) // Deserialize messages from source
                 .connectionProperties(connectionProperties)
-                .consumerName(consumerName);
+                .consumerName(consumerName)
+                .maxFetchRecords(100)
+                .maxFetchTime(Duration.ofSeconds(5));
 
         NatsJetStreamSource<String> natsSource = builder.build();
 

--- a/src/main/java/io/synadia/flink/v0/NatsJetStreamSource.java
+++ b/src/main/java/io/synadia/flink/v0/NatsJetStreamSource.java
@@ -37,7 +37,7 @@ public class NatsJetStreamSource<OutputT> extends NatsSource<OutputT> {
     @Override
     public Boundedness getBoundedness() {
         logger.debug("{} | Boundedness", id);
-        return null; // TODO this varies from NatsSource, understand why
+        return Boundedness.CONTINUOUS_UNBOUNDED; // TODO this varies from NatsSource, understand why
     }
 
     @Override

--- a/src/main/java/io/synadia/flink/v0/NatsJetStreamSource.java
+++ b/src/main/java/io/synadia/flink/v0/NatsJetStreamSource.java
@@ -37,7 +37,7 @@ public class NatsJetStreamSource<OutputT> extends NatsSource<OutputT> {
     @Override
     public Boundedness getBoundedness() {
         logger.debug("{} | Boundedness", id);
-        return Boundedness.CONTINUOUS_UNBOUNDED; // TODO this varies from NatsSource, understand why
+        return sourceConfiguration.getBoundedness(); // TODO this varies from NatsSource, understand why
     }
 
     @Override

--- a/src/main/java/io/synadia/flink/v0/NatsJetStreamSourceBuilder.java
+++ b/src/main/java/io/synadia/flink/v0/NatsJetStreamSourceBuilder.java
@@ -6,6 +6,7 @@ package io.synadia.flink.v0;
 import io.synadia.flink.utils.Constants;
 import io.synadia.flink.utils.PropertiesUtils;
 import io.synadia.flink.v0.payload.PayloadDeserializer;
+import org.apache.flink.api.connector.source.Boundedness;
 
 import java.time.Duration;
 import java.util.Properties;
@@ -23,6 +24,7 @@ public class NatsJetStreamSourceBuilder<OutputT> extends NatsSinkOrSourceBuilder
     private Duration fetchTimeout;
     private int maxFetchRecords;
     private Duration autoAckInterval;
+    private Boundedness boundedness;
 
     public NatsJetStreamSourceBuilder() {
         super(SOURCE_PREFIX);
@@ -32,6 +34,7 @@ public class NatsJetStreamSourceBuilder<OutputT> extends NatsSinkOrSourceBuilder
         fetchTimeout = Duration.ofMillis(DEFAULT_FETCH_TIMEOUT_MS);
         maxFetchRecords = DEFAULT_MAX_FETCH_RECORDS;
         autoAckInterval = Duration.ofMillis(DEFAULT_AUTO_ACK_INTERVAL_MS);
+        boundedness = Boundedness.CONTINUOUS_UNBOUNDED;
     }
 
     /**
@@ -113,6 +116,12 @@ public class NatsJetStreamSourceBuilder<OutputT> extends NatsSinkOrSourceBuilder
         return this;
     }
 
+    public NatsJetStreamSourceBuilder<OutputT> boundness(Boundedness boundedness){
+        this.boundedness = boundedness;
+        return this;
+    }
+
+
     /**
      * Build a NatsJetStreamSource.
      * @return the source
@@ -149,6 +158,6 @@ public class NatsJetStreamSourceBuilder<OutputT> extends NatsSinkOrSourceBuilder
                 fetchOneMessageTimeout,
                 fetchTimeout,
                 maxFetchRecords,
-                autoAckInterval));
+                autoAckInterval, boundedness));
     }
 }

--- a/src/main/java/io/synadia/flink/v0/NatsJetStreamSourceConfiguration.java
+++ b/src/main/java/io/synadia/flink/v0/NatsJetStreamSourceConfiguration.java
@@ -3,6 +3,7 @@
 
 package io.synadia.flink.v0;
 
+import org.apache.flink.api.connector.source.Boundedness;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.connector.base.source.reader.SourceReaderOptions;
 
@@ -20,6 +21,7 @@ public class NatsJetStreamSourceConfiguration implements Serializable {
     private final int maxFetchRecords;
     private final Duration autoAckInterval;
     private final Configuration configuration;
+    private final Boundedness boundedness;
 
     NatsJetStreamSourceConfiguration(String consumerName,
                                             int messageQueueCapacity,
@@ -27,7 +29,8 @@ public class NatsJetStreamSourceConfiguration implements Serializable {
                                             Duration fetchOneMessageTimeout,
                                             Duration fetchTimeout,
                                             int maxFetchRecords,
-                                            Duration autoAckInterval) {
+                                            Duration autoAckInterval,
+                                            Boundedness boundedness) {
         this.consumerName = consumerName;
         this.messageQueueCapacity = messageQueueCapacity;
         this.enableAutoAcknowledgeMessage = enableAutoAcknowledgeMessage;
@@ -37,6 +40,7 @@ public class NatsJetStreamSourceConfiguration implements Serializable {
         this.autoAckInterval = autoAckInterval;
         configuration = new Configuration();
         configuration.setInteger(SourceReaderOptions.ELEMENT_QUEUE_CAPACITY.key(), messageQueueCapacity);
+        this.boundedness = boundedness;
     }
 
     public String getConsumerName() {
@@ -69,5 +73,9 @@ public class NatsJetStreamSourceConfiguration implements Serializable {
 
     public Configuration getConfiguration() {
         return configuration;
+    }
+
+    public Boundedness getBoundedness() {
+        return boundedness;
     }
 }

--- a/src/main/java/io/synadia/flink/v0/emitter/NatsRecordEmitter.java
+++ b/src/main/java/io/synadia/flink/v0/emitter/NatsRecordEmitter.java
@@ -5,17 +5,14 @@ import io.synadia.flink.v0.payload.PayloadDeserializer;
 import io.synadia.flink.v0.source.split.NatsSubjectSplitState;
 import org.apache.flink.api.connector.source.SourceOutput;
 import org.apache.flink.connector.base.source.reader.RecordEmitter;
-import org.apache.flink.util.Collector;
 
 public class NatsRecordEmitter<OutputT>
         implements RecordEmitter<Message, OutputT, NatsSubjectSplitState> {
 
     private final PayloadDeserializer<OutputT> payloadDeserializer;
-    private final SourceOutputWrapper<OutputT> sourceOutputWrapper;
 
     public NatsRecordEmitter(PayloadDeserializer<OutputT> payloadDeserializer) {
         this.payloadDeserializer = payloadDeserializer;
-        this.sourceOutputWrapper = new SourceOutputWrapper<>();
     }
 
     @Override
@@ -23,43 +20,9 @@ public class NatsRecordEmitter<OutputT>
                            SourceOutput<OutputT> output,
                            NatsSubjectSplitState splitState)
             throws Exception {
-        sourceOutputWrapper.setSourceOutput(output);
-        sourceOutputWrapper.setTimestamp(element);
-
         // Deserialize the message and since it to output.
-        payloadDeserializer.getObject(splitState.getSplit().getSubject(), element.getData(), null);
+        output.collect(payloadDeserializer.getObject(splitState.getSplit().getSubject(), element.getData(), element.getHeaders()));
         splitState.getSplit().getCurrentMessages().add(element);
-    }
-
-    private static class SourceOutputWrapper<OutputT> implements Collector<OutputT> {
-
-        private SourceOutput<OutputT> sourceOutput;
-        private long timestamp;
-
-        @Override
-        public void collect(OutputT record) {
-            if (timestamp > 0) {
-                sourceOutput.collect(record, timestamp);
-            } else {
-                sourceOutput.collect(record);
-            }
-        }
-
-        @Override
-        public void close() {
-            // Nothing to do here.
-        }
-
-        private void setSourceOutput(SourceOutput<OutputT> sourceOutput) {
-            this.sourceOutput = sourceOutput;
-        }
-
-        /**
-         * Set the event timestamp.
-         */
-        private void setTimestamp(Message message) {
-            this.timestamp = message.metaData().timestamp().toInstant().toEpochMilli();
-        }
     }
 }
 

--- a/src/main/java/io/synadia/flink/v0/source/reader/NatsSubjectSplitReader.java
+++ b/src/main/java/io/synadia/flink/v0/source/reader/NatsSubjectSplitReader.java
@@ -57,13 +57,14 @@ public class NatsSubjectSplitReader
 
         String splitId = registeredSplit.splitId();
         List<Message> messages = jetStreamSubscription.fetch(sourceConfiguration.getMaxFetchRecords(), sourceConfiguration.getFetchTimeout());
+        messages.forEach((msg)-> {
+            builder.add(splitId,msg);
+        });
         //Stop consuming if running in batch mode and configured size of messages are fetched
         if (sourceConfiguration.getBoundedness() == Boundedness.BOUNDED && messages.size() <= sourceConfiguration.getMaxFetchRecords()){
             builder.addFinishedSplit(splitId);
         }
-        messages.forEach((msg)-> {
-            builder.add(splitId,msg);
-        });
+
         LOG.debug("{} | {} | Finished polling message {}", id, splitId, 1);
 
         return builder.build();

--- a/src/test/java/io/synadia/io/synadia/flink/v0/JsSourceTests.java
+++ b/src/test/java/io/synadia/io/synadia/flink/v0/JsSourceTests.java
@@ -9,11 +9,15 @@ import io.synadia.flink.v0.NatsJetStreamSource;
 import io.synadia.flink.v0.NatsJetStreamSourceBuilder;
 import io.synadia.flink.v0.payload.PayloadDeserializer;
 import io.synadia.flink.v0.payload.StringPayloadDeserializer;
+import io.synadia.flink.v0.payload.StringPayloadSerializer;
+import io.synadia.flink.v0.sink.NatsSink;
+import io.synadia.flink.v0.sink.NatsSinkBuilder;
 import io.synadia.io.synadia.flink.TestBase;
 import org.apache.flink.api.common.eventtime.WatermarkStrategy;
 import org.apache.flink.api.common.restartstrategy.RestartStrategies;
 import org.apache.flink.api.common.time.Time;
 import org.apache.flink.api.connector.source.Boundedness;
+import org.apache.flink.core.execution.JobClient;
 import org.apache.flink.streaming.api.datastream.DataStream;
 import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
 import org.junit.jupiter.api.Test;
@@ -26,7 +30,7 @@ import java.util.List;
 import java.util.Properties;
 
 import static io.nats.client.api.ConsumerConfiguration.INTEGER_UNSET;
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.*;
 
 public class JsSourceTests extends TestBase {
 
@@ -47,6 +51,7 @@ public class JsSourceTests extends TestBase {
     public void testJsSourceBounded() throws Exception {
         final List<Message> syncList = Collections.synchronizedList(new ArrayList<>());
         String sourceSubject = random("sub");
+        String sinkSubject = random("sink");
         String streamName = random("strm");
         String consumerName = random("con");
 
@@ -54,89 +59,138 @@ public class JsSourceTests extends TestBase {
             JetStreamManagement jsm = nc.jetStreamManagement();
             JetStream js = jsm.jetStream();
 
+            // Step 1: Create the source stream and publish messages
             createStream(jsm, streamName, sourceSubject);
             publish(js, sourceSubject, 10);
 
-            ConsumerConfiguration cc = createConsumer(jsm, streamName, sourceSubject, consumerName, INTEGER_UNSET);
+            // Step 2: Create a JetStream consumer
+            createConsumer(jsm, streamName, sourceSubject, consumerName);
 
-            // --------------------------------------------------------------------------------
+            // Step 3: Configure the NATS JetStream Source
+            Properties connectionProperties = defaultConnectionProperties(url);
+            StringPayloadDeserializer deserializer = new StringPayloadDeserializer();
+            NatsJetStreamSourceBuilder<String> builder =
+                    new NatsJetStreamSourceBuilder<String>()
+                            .subjects(sourceSubject)
+                            .payloadDeserializer(deserializer)
+                            .connectionProperties(connectionProperties)
+                            .consumerName(consumerName)
+                            .maxFetchRecords(100)
+                            .maxFetchTime(Duration.ofSeconds(5))
+                            .boundness(Boundedness.BOUNDED);
+
+            // Step 4: Set up Flink Streaming Environment
+            NatsJetStreamSource<String> natsSource = builder.build();
+            StreamExecutionEnvironment env = StreamExecutionEnvironment.getExecutionEnvironment();
+            env.getCheckpointConfig().setCheckpointInterval(10_000L);
+            DataStream<String> ds = env.fromSource(natsSource, WatermarkStrategy.noWatermarks(), "nats-source-input");
+
+            // Step 5: Listen to the sink subject and collect messages into syncList
+            Dispatcher dispatcher = nc.createDispatcher();
+            dispatcher.subscribe(sinkSubject, syncList::add); // Collect sink messages
+
+            // Step 6: Configure a NATS Sink to write processed data
+            NatsSink<String> sink = new NatsSinkBuilder<String>()
+                    .subjects(sinkSubject)
+                    .connectionProperties(connectionProperties)
+                    .payloadSerializer(new StringPayloadSerializer()) // Serialize messages for sink
+                    .build();
+            ds.map(String::toUpperCase).sinkTo(sink);
+
+            // Step 7: Set Flink restart strategy and execute the job asynchronously
+            env.setRestartStrategy(RestartStrategies.fixedDelayRestart(5, Time.seconds(5)));
+            env.executeAsync("TestJsSourceBounded");
+
+            // Step 8: Wait for processing to complete
+            Thread.sleep(12_000);
+
+            // Step 9: Cleanup and validation
+            env.close();
+            assertEquals(10, syncList.size(), "All 10 messages should be received at the sink.");
+            jsm.deleteStream(streamName);
+            nc.close();
+        });
+    }
+
+
+    @Test
+    public void testJsSourceUnbounded() throws Exception {
+        final List<Message> syncList = Collections.synchronizedList(new ArrayList<>());
+        String sourceSubject = random("sub");
+        String sinkSubject = random("sink");
+        String streamName = random("strm");
+        String consumerName = random("con");
+
+        runInServer(true, (nc, url) -> {
+            JetStreamManagement jsm = nc.jetStreamManagement();
+            JetStream js = jsm.jetStream();
+
+            // Step 1: Create the source stream and publish messages
+            createStream(jsm, streamName, sourceSubject);
+            createConsumer(jsm, streamName, sourceSubject, consumerName);
+
+            // Step 2: NATS JetStream Source configuration
             Properties connectionProperties = defaultConnectionProperties(url);
             PayloadDeserializer<String> deserializer = new StringPayloadDeserializer();
-            NatsJetStreamSourceBuilder<String> builder =
-                new NatsJetStreamSourceBuilder<String>()
+            NatsJetStreamSourceBuilder<String> builder = new NatsJetStreamSourceBuilder<String>()
                     .subjects(sourceSubject)
                     .payloadDeserializer(deserializer)
                     .connectionProperties(connectionProperties)
                     .consumerName(consumerName)
-                    .maxFetchRecords(10)
+                    .maxFetchRecords(100)
                     .maxFetchTime(Duration.ofSeconds(5))
-                    .boundness(Boundedness.BOUNDED);
+                    .boundness(Boundedness.CONTINUOUS_UNBOUNDED);
 
-            NatsJetStreamSource<String> natsSource = builder.build();
-            StreamExecutionEnvironment env = getStreamExecutionEnvironment();
-            env.getCheckpointConfig().setCheckpointInterval(11_000L);
-            DataStream<String> ds = env.fromSource(natsSource, WatermarkStrategy.noWatermarks(), "nats-source-input");
-
-            ds.map(String::toUpperCase); //To Avoid Sink Dependency
-            env.setRestartStrategy(RestartStrategies.fixedDelayRestart(5, Time.seconds(5)));
-            env.executeAsync("TestJsSourceBounded");
-
-            Thread.sleep(12_000);
-            env.close();
-            ConsumerInfo ci = jsm.getConsumerInfo(streamName, consumerName);
-            SequenceInfo sequenceInfo = ci.getDelivered();
-            assertTrue(sequenceInfo.getStreamSequence() >= 2);
-
-        });
-    }
-
-    @Test
-    public void testJsSourceUnbounded() throws Exception {
-        String sourceSubject = random("sub");
-        String streamName = random("strm");
-        String consumerName = random("con");
-
-        runInServer(true, (nc, url) -> {
-            JetStreamManagement jsm = nc.jetStreamManagement();
-            JetStream js = jsm.jetStream();
-            createStream(jsm, streamName, sourceSubject);
-
-            ConsumerConfiguration cc = createConsumer(jsm, streamName, sourceSubject, consumerName, 100);
-            // --------------------------------------------------------------------------------
-            Properties connectionProperties = defaultConnectionProperties(url);
-            PayloadDeserializer<String> deserializer = new StringPayloadDeserializer();
-            NatsJetStreamSourceBuilder<String> builder = new NatsJetStreamSourceBuilder<String>()
-                .subjects(sourceSubject)
-                .payloadDeserializer(deserializer)
-                .connectionProperties(connectionProperties)
-                .consumerName(consumerName)
-                .maxFetchRecords(100)
-                .maxFetchTime(Duration.ofSeconds(5))
-                .boundness(Boundedness.CONTINUOUS_UNBOUNDED);
-
-            // Flink environment setup
+            // Step 3: Flink environment setup
             StreamExecutionEnvironment env = StreamExecutionEnvironment.getExecutionEnvironment();
 
+            // Source: Read from NATS
             DataStream<String> ds = env.fromSource(builder.build(), WatermarkStrategy.noWatermarks(), "nats-source-input");
-            ds.map(String::toUpperCase);
 
-            // Running Flink job in a separate thread
-            env.executeAsync("TestJsSourceUnbounded");
-            publish(js, sourceSubject, 5, 0);
+            // Step 4: Setup a Dispatcher to listen to the sink subject and capture messages
+            Dispatcher d = nc.createDispatcher();
+            d.subscribe(sinkSubject, syncList::add);
 
-            Thread.sleep(15_000L); // Increased sleep time to ensure messages are processed
+            // Sink: Write to a different subject
+            NatsSink<String> sink = new NatsSinkBuilder<String>()
+                    .subjects(sinkSubject)
+                    .connectionProperties(connectionProperties)
+                    .payloadSerializer(new StringPayloadSerializer()) // Serialize messages for sink
+                    .build();
+            ds.map(String::toUpperCase).sinkTo(sink);
+
+            // Step 5: Execute the Flink job asynchronously
+            JobClient jobClient = env.executeAsync("TestJsSourceUnbounded");
+
+            // Step 6: Publish messages to NATS JetStream
+            publish(js, sourceSubject, 5, 100);
+
+            // Wait for messages to process
+            Thread.sleep(10_000);
+
+            // Step 7: Verify received messages at sink
+            assertEquals(5, syncList.size(), "All 5 messages should be received at the sink.");
+
+            // Step 8: Cancel the Flink job gracefully
+            try {
+                jobClient.cancel().get();
+                System.out.println("Flink job canceled successfully.");
+            } catch (Exception e) {
+                e.printStackTrace();
+                fail("Failed to cancel Flink job: " + e.getMessage());
+            }
+
+            // Step 9: Cleanup
             env.close();
-            SequenceInfo sequenceInfo = nc.jetStream().getConsumerContext(streamName, consumerName).getConsumerInfo().getDelivered();
-            assertTrue(sequenceInfo.getStreamSequence() >= 5);
+            jsm.deleteStream(streamName);
         });
     }
 
-    private static ConsumerConfiguration createConsumer(JetStreamManagement jsm, String streamName, String sourceSubject, String consumerName, int maxBatch) throws IOException, JetStreamApiException {
+    private static ConsumerConfiguration createConsumer(JetStreamManagement jsm, String streamName, String sourceSubject, String consumerName) throws IOException, JetStreamApiException {
         ConsumerConfiguration cc = ConsumerConfiguration.builder()
             .durable(consumerName)
             .ackPolicy(AckPolicy.All)
             .filterSubject(sourceSubject)
-            .maxBatch(maxBatch)
             .build();
         jsm.addOrUpdateConsumer(streamName, cc);
         return cc;
@@ -146,7 +200,6 @@ public class JsSourceTests extends TestBase {
         StreamConfiguration streamConfig = StreamConfiguration.builder()
             .name(streamName)
             .subjects(sourceSubject)
-            .storageType(StorageType.Memory)
             .build();
         jsm.addStream(streamConfig);
     }


### PR DESCRIPTION
- `testJsSourceBounded`:
  - Added `assertEquals` to validate the size of `syncList` for verification of received messages in Sink instead of Source.

- `testJsSourceUnbounded`:
  - Replaced manual thread interruption with Flink's `JobClient` for graceful job execution control.
  - Used `JobClient.cancel()` to stop the unbounded Flink job after a fixed duration, ensuring clean shutdown.
  - Added `assertEquals` to validate the size of `syncList` for verification of received messages in Sink instead of Source.